### PR TITLE
Only add internal header tests if exists.

### DIFF
--- a/test/headers/CMakeLists.txt
+++ b/test/headers/CMakeLists.txt
@@ -28,10 +28,13 @@ foreach(dir ${subdirs})
         ${CMAKE_CURRENT_SOURCE_DIR}/compile_headers.py
             ${public_inc_dir} ${CMAKE_CXX_COMPILER} "-I${root_inc_dir} -I${public_inc_dir} ${CMAKE_CXX_FLAGS}" "--exclusions" ${exclusions})
 
-    # Test that each internal header compiles stand-alone.
-    add_test(stand-alone-${location}-internal-headers
-        ${CMAKE_CURRENT_SOURCE_DIR}/compile_headers.py
-            ${internal_inc_dir} ${CMAKE_CXX_COMPILER} "-I${root_inc_dir} -I${internal_inc_dir} ${CMAKE_CXX_FLAGS}" "--exclusions" ${exclusions})
+    # Test that each internal header compiles stand-alone,
+    # if internal headers exist.
+    if(EXISTS ${internal_inc_dir})
+      add_test(stand-alone-${location}-internal-headers
+          ${CMAKE_CURRENT_SOURCE_DIR}/compile_headers.py
+              ${internal_inc_dir} ${CMAKE_CXX_COMPILER} "-I${root_inc_dir} -I${internal_inc_dir} ${CMAKE_CXX_FLAGS}" "--exclusions" ${exclusions})
+    endif(EXISTS ${internal_inc_dir})
 
     # Test that no public header includes an internal header
     add_test(clean-public-${location}-headers ${CMAKE_CURRENT_SOURCE_DIR}/check_public_headers.py ${public_inc_dir})


### PR DESCRIPTION
Only add a teset for standalone compilation of internal include
directories if the directory exists on disk.