### PR TITLE
Fix autoclean conflict with new glib.

### DIFF
--- a/include/unity/util/GlibMemory.h
+++ b/include/unity/util/GlibMemory.h
@@ -210,7 +210,10 @@ inline GSourceManager g_source_manager(guint id)
 /**
  * Manually add extra definitions for gchar* and gchar**
  */
-#if !GLIB_CHECK_VERSION(2, 57, 2)
+#if GLIB_CHECK_VERSION(2, 57, 2)
+typedef GRefStringSPtr gcharSPtr;
+typedef GRefStringUPtr gcharUPtr;
+#else
 UNITY_UTIL_DEFINE_GLIB_SMART_POINTERS(gchar, g_free)
 #endif
 typedef gchar* gcharv;

--- a/include/unity/util/GlibMemory.h
+++ b/include/unity/util/GlibMemory.h
@@ -210,7 +210,9 @@ inline GSourceManager g_source_manager(guint id)
 /**
  * Manually add extra definitions for gchar* and gchar**
  */
+#if !GLIB_CHECK_VERSION(2, 57, 2)
 UNITY_UTIL_DEFINE_GLIB_SMART_POINTERS(gchar, g_free)
+#endif
 typedef gchar* gcharv;
 UNITY_UTIL_DEFINE_GLIB_SMART_POINTERS(gcharv, g_strfreev)
 


### PR DESCRIPTION
The new glib 2.57.2 version introduces reference counted strings, which
causes a redefinition scenario with our autocleanup of gchar here. So,
only include this definition when building against older glib versions.

Fixes #4