### PR TITLE
Resolve file conflict with Breaks/Conflicts.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,8 +30,8 @@ Package: libunity-api1
 Architecture: any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends},
-Breaks: libunity-api0
-Conflits: libunity-api0
+Conflicts: libunity-api0
+Replaces: libunity-api0
 Depends: ${misc:Depends},
          ${shlibs:Depends},
 Description: API for Unity shell integration

--- a/debian/control
+++ b/debian/control
@@ -24,17 +24,14 @@ Build-Depends: cmake,
                qtdeclarative5-qtquick2-plugin,
                qtdeclarative5-test-plugin,
 Standards-Version: 3.9.4
-Homepage: https://launchpad.net/unity-api
-# If you aren't a member of ~unity-team but need to upload
-# packaging changes, just go ahead. ~unity-team will notice
-# and sync up the code again.
-Vcs-Bzr: lp:unity-api
-Vcs-Browser: https://code.launchpad.net/unity-api
+Homepage: https://github.com/ubports/unity-api
 
 Package: libunity-api1
 Architecture: any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends},
+Breaks: libunity-api0
+Conflits: libunity-api0
 Depends: ${misc:Depends},
          ${shlibs:Depends},
 Description: API for Unity shell integration


### PR DESCRIPTION
This adds a Breaks/Conflicts on libunity-api0 for libunity-api1 to resolve
the installability issue when upgrading a system which already ahs the former
installed, due to the ABI break being released without the package name being
fixed to match. Also change the URL to the GitHub URL.

Fixes #20 and ubports/crossbuilder#27